### PR TITLE
top_level startup code: fix infinite loop when defining a user path

### DIFF
--- a/ballcosmos/top_level.py
+++ b/ballcosmos/top_level.py
@@ -17,12 +17,12 @@ def define_user_path(start_dir = os.getcwd()):
   """
   current_dir = os.path.abspath(start_dir)
   while True:
-    if os.path.isfile("/".join([current_dir, 'userpath.txt'])):
+    if os.path.isfile(os.path.join(current_dir, 'userpath.txt')):
       USERPATH = current_dir
       break
     else:
       old_current_dir = current_dir
-      current_dir = os.path.abspath("/".join([current_dir, '..']))
+      current_dir = os.path.abspath(os.path.join(current_dir, os.pardir))
       if old_current_dir == current_dir:
         # Hit the root dir - give up
         break


### PR DESCRIPTION
Without this change, the code in the master branch goes into an infinite loop right at the start of any script that imports `from ballcosmos.script import *`.

The problem seems to be in how the `join` function works when it reaches the root path (`/` on Linux).

I am only testing this change on Linux but I think it should be valid for Windows as well.

![Screenshot from 2021-08-17 11-44-51](https://user-images.githubusercontent.com/452547/129704818-5a130985-048c-43a7-a29e-2604f7a26e1b.png)
